### PR TITLE
feat(auth): 이메일 회원가입 API 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.security:spring-security-crypto'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 
 

--- a/src/main/java/com/rebook/user/config/AuthConfig.java
+++ b/src/main/java/com/rebook/user/config/AuthConfig.java
@@ -1,0 +1,15 @@
+package com.rebook.user.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class AuthConfig {
+
+    @Bean
+    PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/rebook/user/controller/AuthController.java
+++ b/src/main/java/com/rebook/user/controller/AuthController.java
@@ -1,0 +1,44 @@
+package com.rebook.user.controller;
+
+import com.rebook.jwt.JwtUtil;
+import com.rebook.user.controller.request.SignupRequestSchema;
+import com.rebook.user.controller.response.JwtResponse;
+import com.rebook.user.service.UserService;
+import com.rebook.user.service.dto.LoggedInUser;
+import com.rebook.user.service.dto.UserCreateCommand;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.Instant;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping(value = "/api/v1/auth", produces = "application/json")
+public class AuthController {
+    private final UserService userService;
+    private final JwtUtil jwtUtil;
+
+    @Operation(
+            summary = "이메일로 회원가입",
+            description = "이메일로 회원가입을 합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "회원가입 성공 시 JWT 토큰을 반환합니다.")
+            }
+    )
+    @PostMapping("/signup")
+    public ResponseEntity<JwtResponse> signup(@RequestBody SignupRequestSchema body) {
+        LoggedInUser loggedInUser = userService.createUser(
+                UserCreateCommand
+                        .builder()
+                        .email(body.getEmail())
+                        .nickname(body.getNickname())
+                        .password(body.getPassword())
+                        .build()
+        );
+        String token = jwtUtil.createToken(loggedInUser, Instant.now());
+        return ResponseEntity.status(201).body(new JwtResponse(token));
+    }
+}

--- a/src/main/java/com/rebook/user/controller/request/SignupRequestSchema.java
+++ b/src/main/java/com/rebook/user/controller/request/SignupRequestSchema.java
@@ -1,0 +1,14 @@
+package com.rebook.user.controller.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SignupRequestSchema {
+    private String email;
+    private String nickname;
+    private String password;
+}

--- a/src/main/java/com/rebook/user/domain/UserEntity.java
+++ b/src/main/java/com/rebook/user/domain/UserEntity.java
@@ -21,6 +21,9 @@ public class UserEntity extends BaseEntity {
     @Column(name = "nickname", nullable = false)
     private String nickname;
 
+    @Column(name = "password")
+    private String password;
+
     @Column(name = "email", nullable = false)
     private String email;
 

--- a/src/main/java/com/rebook/user/domain/UserEntity.java
+++ b/src/main/java/com/rebook/user/domain/UserEntity.java
@@ -35,10 +35,11 @@ public class UserEntity extends BaseEntity {
     private String socialId; // 로그인한 소셜 타입의 식별자 값 (일반 로그인인 경우 null)
 
     @Builder
-    public UserEntity(Long id, String nickname, String email, Role role, SocialType socialType, String socialId) {
+    public UserEntity(Long id, String nickname, String email, String password, Role role, SocialType socialType, String socialId) {
         this.id = id;
         this.nickname = nickname;
         this.email = email;
+        this.password = password;
         this.role = role;
         this.socialType = socialType;
         this.socialId = socialId;

--- a/src/main/java/com/rebook/user/service/LoginService.java
+++ b/src/main/java/com/rebook/user/service/LoginService.java
@@ -2,8 +2,9 @@ package com.rebook.user.service;
 
 import com.rebook.user.config.OAuthServiceProvider;
 import com.rebook.user.service.dto.LoggedInUser;
-import com.rebook.user.service.dto.UserCommand;
+import com.rebook.user.service.dto.SocialUserCreateCommand;
 import com.rebook.user.util.OAuthService;
+import com.rebook.user.util.SocialUserProfile;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -20,8 +21,15 @@ public class LoginService {
             throw new IllegalArgumentException("Unsupported registrationId: " + registrationId);
         }
         String accessToken = oauthProvider.getAccessToken(code);
-        UserCommand userCommand = oauthProvider.getUserProfile(accessToken);
-        return userService.createUser(userCommand);
+        SocialUserProfile userProfile = oauthProvider.getUserProfile(accessToken);
+        return userService.createSocialUser(
+                SocialUserCreateCommand.builder()
+                        .email(userProfile.getEmail())
+                        .name(userProfile.getName())
+                        .socialId(userProfile.getSocialId())
+                        .socialType(userProfile.getSocialType())
+                        .build()
+        );
     }
 
     public String getAuthorizationUrl(String registrationId) {
@@ -31,5 +39,4 @@ public class LoginService {
         }
         return oauthProvider.getAuthorizationUrl();
     }
-
 }

--- a/src/main/java/com/rebook/user/service/UserService.java
+++ b/src/main/java/com/rebook/user/service/UserService.java
@@ -4,9 +4,11 @@ import com.rebook.user.domain.Role;
 import com.rebook.user.domain.SocialType;
 import com.rebook.user.domain.UserEntity;
 import com.rebook.user.service.dto.LoggedInUser;
-import com.rebook.user.service.dto.UserCommand;
+import com.rebook.user.service.dto.SocialUserCreateCommand;
 import com.rebook.user.repository.UserRepository;
+import com.rebook.user.service.dto.UserCreateCommand;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
@@ -15,9 +17,10 @@ import java.util.Optional;
 @Service
 public class UserService {
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
-    public LoggedInUser createUser(UserCommand userCommand) {
-        String socialId = userCommand.getSocialId();
+    public LoggedInUser createSocialUser(SocialUserCreateCommand command) {
+        String socialId = command.getSocialId();
         Optional<UserEntity> existingUser = userRepository.findBySocialId(socialId);
 
         //존재하는 회원일 경우
@@ -27,10 +30,28 @@ public class UserService {
 
         //아닐 경우 신규 DB에 저장
         UserEntity newUser = UserEntity.builder()
-                .email(userCommand.getEmail())
-                .nickname(userCommand.getName())
-                .socialType(SocialType.valueOf(userCommand.getSocialType()))
-                .socialId(userCommand.getSocialId())
+                .email(command.getEmail())
+                .nickname(command.getName())
+                .socialType(SocialType.valueOf(command.getSocialType()))
+                .socialId(command.getSocialId())
+                .role(Role.USER)
+                .build();
+        return LoggedInUser.fromEntity(userRepository.save(newUser));
+    }
+
+    public LoggedInUser createUser(UserCreateCommand command) {
+        String email = command.getEmail();
+        Optional<UserEntity> existingUser = userRepository.findByEmail(email);
+
+        if (existingUser.isPresent()) {
+            return LoggedInUser.fromEntity(existingUser.get());
+        }
+
+        String encryptedPassword = passwordEncoder.encode(command.getPassword());
+        UserEntity newUser = UserEntity.builder()
+                .email(command.getEmail())
+                .nickname(command.getNickname())
+                .password(encryptedPassword)
                 .role(Role.USER)
                 .build();
         return LoggedInUser.fromEntity(userRepository.save(newUser));

--- a/src/main/java/com/rebook/user/service/dto/SocialUserCreateCommand.java
+++ b/src/main/java/com/rebook/user/service/dto/SocialUserCreateCommand.java
@@ -1,6 +1,5 @@
 package com.rebook.user.service.dto;
 
-import com.rebook.user.domain.Role;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -8,7 +7,7 @@ import lombok.Setter;
 @Setter
 @Getter
 @Builder
-public class UserCommand {
+public class SocialUserCreateCommand {
     String name;
     String email;
     String socialId;

--- a/src/main/java/com/rebook/user/service/dto/UserCreateCommand.java
+++ b/src/main/java/com/rebook/user/service/dto/UserCreateCommand.java
@@ -1,0 +1,12 @@
+package com.rebook.user.service.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserCreateCommand {
+    String nickname;
+    String email;
+    String password;
+}

--- a/src/main/java/com/rebook/user/util/GoogleOAuthService.java
+++ b/src/main/java/com/rebook/user/util/GoogleOAuthService.java
@@ -1,7 +1,6 @@
 package com.rebook.user.util;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.rebook.user.service.dto.UserCommand;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.*;
 import org.springframework.stereotype.Component;
@@ -61,12 +60,12 @@ public class GoogleOAuthService implements OAuthService {
 
 
     @Override
-    public UserCommand getUserProfile(String accessToken) {
+    public SocialUserProfile getUserProfile(String accessToken) {
         JsonNode userResource = getUserResource(accessToken);
         String id = userResource.get("sub").asText();
         String email = userResource.get("email").asText();
         String name = userResource.get("name").asText();
-        return UserCommand.builder()
+        return SocialUserProfile.builder()
                 .name(name)
                 .email(email)
                 .socialId(id)

--- a/src/main/java/com/rebook/user/util/OAuthService.java
+++ b/src/main/java/com/rebook/user/util/OAuthService.java
@@ -1,11 +1,10 @@
 package com.rebook.user.util;
 
-import com.rebook.user.service.dto.UserCommand;
 
 public interface OAuthService {
     String getAuthorizationUrl();
 
     String getAccessToken(String authorizationCode);
 
-    UserCommand getUserProfile(String accessToken);
+    SocialUserProfile getUserProfile(String accessToken);
 }

--- a/src/main/java/com/rebook/user/util/SocialUserProfile.java
+++ b/src/main/java/com/rebook/user/util/SocialUserProfile.java
@@ -1,0 +1,13 @@
+package com.rebook.user.util;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SocialUserProfile {
+    private String name;
+    private String email;
+    private String socialId;
+    private String socialType;
+}


### PR DESCRIPTION
1. 이메일로 회원가입을 위한 API를 추가합니다.
- API 경로는 /api/v1/auth/signup

2. PasswordEncoder
- 비밀번호 단방향 해시를 적용하기 위해 SpringSecurity Crypto 의존성 추가
- 암호화에 사용되는 Salt가 무엇인지 공부해보세요~ https://jhkimmm.tistory.com/24