### PR TITLE
chore: docker-compose blue, green 컨테이너 설정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,5 +14,18 @@ services:
     volumes:
       - mysqldata:/var/lib/mysql
 
+  blue:
+    image: sadang-boogi/howread-api:latest
+    cotainer_name: blue
+    restart: always
+    ports:
+      - 8081:8080
+  green:
+    image: sadang-boogi/howread-api:latest
+    container_name: green
+    restart: always
+    ports:
+      - 8082:8080
+
 volumes:
   mysqldata:

--- a/src/main/resources/db/migration/V3__alter_table.sql
+++ b/src/main/resources/db/migration/V3__alter_table.sql
@@ -1,2 +1,0 @@
-ALTER TABLE users
-    ADD last_logged_in_at datetime NULL;

--- a/src/main/resources/db/migration/V3__alter_table.sql
+++ b/src/main/resources/db/migration/V3__alter_table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+    ADD last_logged_in_at datetime NULL;


### PR DESCRIPTION
AWS EC2에서 무중단 배포를 하기위한 Blue-Green 컨테이너를 띄우기 위한 docker-compose 파일을 수정합니다.

blue는 8081 포트, green은 8082포트로 nginx에서 blue(8081)을 보고있는 상태에서 배포를하려고하면 green을 최신으로 변경한 후, nginx를 green으로 보도록 변경합니다.

예시) Nginx 변경 예시
1. green -> blue로 변경 시 /etc/nginx/sites-available/blue -> /etc/nginx/sites-enabled/default 파일 복사
2. blue -> green로 변경 시 /etc/nginx/sites-avaiable/green -> /etc/nginx/sites-enabled/default 파일 복사
3. sudo systemctl restart nginx

