### PR TITLE
fix: Book을 삭제했을 때 연관된 BookHashtag가 삭제되지 않던 오류 수정

### DIFF
--- a/src/main/java/com/rebook/book/service/BookService.java
+++ b/src/main/java/com/rebook/book/service/BookService.java
@@ -94,6 +94,8 @@ public class BookService {
                 .orElseThrow(() -> new NotFoundException(NOT_FOUND_BOOK_ID));
         book.getReviews().forEach(ReviewEntity::softDelete);
         book.softDelete();
+        book.getBookHashtags()
+                .forEach(BaseEntity::softDelete);
     }
 
     private void setHashtag(List<HashtagEntity> hashtags, BookEntity book) {


### PR DESCRIPTION
Book을 삭제한다면 삭제하는 Book에 걸려있던 BookHashtag의 값들 역시 데이터베이스에서 삭제 처리되어야 했음
하지만 현재 우리 서비스에서는 Delete를 직접 구현해서 사용하고 있었기 때문에 JPA의 옵션인 cascade가 동작하지 않았음
때문에 Book을 삭제할 때 연관된 BookHashtag도 삭제하는 코드를 추가해주었음