### PR TITLE
feat: 스터디 기능 추가

### DIFF
--- a/src/main/java/com/rebook/study/domain/StudyEntity.java
+++ b/src/main/java/com/rebook/study/domain/StudyEntity.java
@@ -1,0 +1,36 @@
+package com.rebook.study.domain;
+
+import com.rebook.common.domain.BaseEntity;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Min;
+import lombok.*;
+import org.hibernate.annotations.Comment;
+import org.hibernate.annotations.SQLRestriction;
+
+@SQLRestriction(value = "is_deleted = false")
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "study")
+@Entity
+public class StudyEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Min(value = 2, message = "최소 참여 인원은 2명 이상이어야 합니다.")
+    @Column(name = "max_members", nullable = false)
+    private int maxMembers;
+
+    @Comment("스터디 공개 여부")
+    @Column(name = "is_public", nullable = false)
+    private boolean isPublic;
+
+    @Column(name = "password")
+    private String password;
+}

--- a/src/main/java/com/rebook/study/domain/StudyGroupEntity.java
+++ b/src/main/java/com/rebook/study/domain/StudyGroupEntity.java
@@ -12,9 +12,9 @@ import org.hibernate.annotations.SQLRestriction;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Table(name = "study")
+@Table(name = "study_group")
 @Entity
-public class StudyEntity extends BaseEntity {
+public class StudyGroupEntity extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/rebook/study/domain/StudyGroupEntity.java
+++ b/src/main/java/com/rebook/study/domain/StudyGroupEntity.java
@@ -30,7 +30,4 @@ public class StudyGroupEntity extends BaseEntity {
     @Comment("스터디 공개 여부")
     @Column(name = "is_public", nullable = false)
     private boolean isPublic;
-
-    @Column(name = "password")
-    private String password;
 }


### PR DESCRIPTION
스터디 기능
--
- [ ] 1. 유저는 스터디와 1:N이다.
- [ ] 2. 스터디는 스터디장, 스터디원으로 나눠진다.
- [ ] 3. 스터디장은 스터디를 만든 사람이고, 스터디장은 양도가 가능하다. (양도는 이후 추가)
- [x] 4. 스터디는 스터디명, 스터디 최대 인원수, 스터디 공개 여부를 필드로 갖는다.
- [ ] 5. 스터디장은 스터디에서 읽을 책을 등록할 수 있다. (등록 가능한 책은 어드민이 미리 등록해둔 책만 가능)
- [ ] 6. 스터디장은 읽을 책을 등록할 때 일정을 등록할 수 있다. (예를 들어서 1장은 2024.07.01부터 2024.07.08까지)
- [ ] 7. 스터디장은 스터디원을 추방할 수 있다.
- [ ] 8. 비공개 스터디는 참여시 비밀번호를 입력해야 참여가 가능하다.
- [ ] 9. 공개 스터디 참여가 자유로이 가능하다.

