### PR TITLE
chore : S3, CloudFront 설정

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,8 @@ jobs:
           GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
           GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
           GOOGLE_REDIRECT_URI: ${{ secrets.GOOGLE_REDIRECT_URI }}
+          WS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
+          AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
         run: echo "Environment variables set"
 
       - name: Set environment variables
@@ -41,6 +43,8 @@ jobs:
           echo "GOOGLE_OAUTH_CLIENT_ID=${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}" >> $GITHUB_ENV
           echo "GOOGLE_OAUTH_CLIENT_SECRET=${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}" >> $GITHUB_ENV
           echo "GOOGLE_REDIRECT_URI=${{ secrets.GOOGLE_REDIRECT_URI }}" >> $GITHUB_ENV
+          echo "AWS_ACCESS_KEY=${{ secrets.AWS_ACCESS_KEY }}" >> $GITHUB_ENV
+          echo "AWS_SECRET_KEY=${{ secrets.AWS_SECRET_KEY }}" >> $GITHUB_ENV
 
       - name: Run tests
         run: SPRING_PROFILES_ACTIVE=test ./gradlew --info test

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,8 @@ dependencies {
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
 
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
 

--- a/src/main/java/com/rebook/image/config/S3Config.java
+++ b/src/main/java/com/rebook/image/config/S3Config.java
@@ -11,10 +11,10 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class S3Config {
-    @Value("${cloud.aws.credentials.accessKey}")
+    @Value("${cloud.aws.credentials.access-key}")
     private String accessKey;
 
-    @Value("${cloud.aws.credentials.secretKey}")
+    @Value("${cloud.aws.credentials.secret-key}")
     private String secretKey;
 
     @Value("${cloud.aws.region.static}")

--- a/src/main/java/com/rebook/image/config/S3Config.java
+++ b/src/main/java/com/rebook/image/config/S3Config.java
@@ -1,0 +1,33 @@
+package com.rebook.image.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region)
+                .build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,11 +49,11 @@ app:
 cloud:
   aws:
     credentials:
-      accessKey: ${AWS_ACCESS_KEY}
-      secretKey: ${AWS_SECRET_KEY}
+      access-key: ${AWS_ACCESS_KEY}
+      secret-key: ${AWS_SECRET_KEY}
     s3:
-      bucketName: howread-dev-assets
-      baseUrl: static.howread.net/
+      bucket-name: howread-dev-assets
+      base-url: static.howread.net/
     region:
       static: ap-northeast-2
     stack:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,3 +44,17 @@ app:
       - "https://www.howread.net"
       - "https://howread.net"
       - "http://localhost:3000"
+
+    # S3
+cloud:
+  aws:
+    credentials:
+      accessKey: ${AWS_ACCESS_KEY}
+      secretKey: ${AWS_SECRET_KEY}
+    s3:
+      bucketName: howread-dev-assets
+      baseUrl: static.howread.net/
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -26,3 +26,17 @@ spring:
 jwt:
   secret: test_secret_key
   token-validity-in-seconds: 1209600
+
+  # S3
+cloud:
+  aws:
+    credentials:
+      access-key: ${AWS_ACCESS_KEY}
+      secret-key: ${AWS_SECRET_KEY}
+    s3:
+      bucket-name: howread-dev-assets
+      base-url: static.howread.net/
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false


### PR DESCRIPTION
# 📄 Summary

## 이미지 업로드를 위한 S3 및 CloudFront 설정

---

1. **Build에 S3 연동을 위한 Spring Cloud 의존성 추가**
2. **`application.yml`에 S3 설정과 AWS 자격 증명 설정 추가**
3. **S3 버켓 생성 및 static.howread.net을 통해 이미지를 가져올 수 있게 CloudFront 설정**

---

## 설정 참고 자료

- **S3 접근을 위한 AWS 엑세스키 설정 <span style="color:red;">(필수)</span> :** [AWS 엑세스키 설정 가이드](https://hyunki99.tistory.com/94) 
- **S3와 CloudFront 설정 참고 :** [Spring Boot React AWS S3 AWS CloudFront를 활용한 파일 업로드](https://velog.io/@hyerimkimm/AWS-S3-CloudFront-Route-53-ACM-%EC%9D%B4%EC%9A%A9%ED%95%B4%EC%84%9C-%EC%9B%B9%ED%8E%98%EC%9D%B4%EC%A7%80-%EB%B0%B0%ED%8F%AC%ED%95%98%EA%B8%B0)
- **CloudFront 대체 도메인 설정 참고:** [CloudFront-대체-도메인-구성](https://three-beans.tistory.com/entry/AWSCloudFront-CloudFront%EB%A1%9C-S3-%EC%BB%A8%ED%85%90%EC%B8%A0-%EC%A0%9C%EA%B3%B5%ED%95%98%EA%B8%B0-%E2%91%A1-CloudFront-%EB%8C%80%EC%B2%B4-%EB%8F%84%EB%A9%94%EC%9D%B8-%EA%B5%AC%EC%84%B1)

---

### `application.yml` 설정 예시

```yaml
aws:
  credentials:
    accessKey: ${AWS_ACCESS_KEY}
    secretKey: ${AWS_SECRET_KEY}
    s3:
      bucketName: howread-dev-assets 
      baseUrl: static.howread.net/
    region:
      static: ap-northeast-2
    stack:
      auto: false
