### PR TITLE
fix : CORS 설정 업데이트

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,6 +41,7 @@ jwt:
 app:
   cors:
     allow-hosts:
+      - "https://api.howread.net"
       - "https://www.howread.net"
       - "https://howread.net"
       - "http://localhost:3000"


### PR DESCRIPTION
# 📄 Summary

## api.howread.net 도메인을 포함하도록 CORS 설정 업데이트 

- **문제점**: Swagger에서 403 오류가 발생했지만, 실제로는 CORS 오류였음.
- **해결 방법**: CORS 설정에 `https://api.howread.net` 도메인을 추가하여 문제 해결.
- **적용된 변경 사항**:
  - allowed CORS hosts 목록에 `https://api.howread.net` 추가.
